### PR TITLE
31 kindtoticket

### DIFF
--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -7,22 +7,15 @@ class Attendee < ActiveRecord::Base
 
   validates :name, presence: true, allow_blank: false
   validates :tshirt, allow_nil: true, inclusion: { in: Attendee::Tshirt::SIZES }
-  validates :kind, presence: true, inclusion: { in: Attendee::Kind::TYPES }
   validates :is_public, inclusion: { in: [true, false] }
 
   before_validation :cleanup_twitter
   before_validation :set_name
-  before_validation :set_kind
 
   private
 
   def set_name
     self.name = "#{first_name.to_s.strip} #{last_name.to_s.strip}"
-    true
-  end
-
-  def set_kind
-    self.kind ||= Attendee::Kind::REGULAR
     true
   end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -7,4 +7,13 @@ class Ticket < ActiveRecord::Base
 
   validates :attendee_id, presence: true
   validates :event_id, presence: true, uniqueness: { scope: :attendee_id }
+  validates :kind, presence: true, inclusion: { in: Ticket::Kind::TYPES }
+
+  before_validation :set_kind
+
+  def set_kind
+    self.kind ||= Ticket::Kind::REGULAR
+    true
+  end
+
 end

--- a/app/models/ticket/kind.rb
+++ b/app/models/ticket/kind.rb
@@ -1,4 +1,4 @@
-class Attendee
+class Ticket
   class Kind
     REGULAR = 1.freeze
     CREW =    2.freeze

--- a/db/migrate/20130406140433_movingkindtoticket.rb
+++ b/db/migrate/20130406140433_movingkindtoticket.rb
@@ -1,0 +1,6 @@
+class Movingkindtoticket < ActiveRecord::Migration
+  def change
+    remove_column :attendees, :kind
+    add_column :tickets, :kind, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121124134448) do
+ActiveRecord::Schema.define(:version => 20130406140433) do
 
   create_table "attendees", :force => true do |t|
     t.string   "first_name"
@@ -21,14 +21,12 @@ ActiveRecord::Schema.define(:version => 20121124134448) do
     t.string   "twitter"
     t.integer  "tshirt"
     t.text     "diet"
-    t.integer  "kind"
     t.boolean  "is_public",    :default => true
     t.text     "notes"
     t.datetime "created_at",                     :null => false
     t.datetime "updated_at",                     :null => false
   end
 
-  add_index "attendees", ["kind"], :name => "index_attendees_on_kind"
   add_index "attendees", ["name"], :name => "index_attendees_on_name"
 
   create_table "emails", :force => true do |t|
@@ -78,6 +76,7 @@ ActiveRecord::Schema.define(:version => 20121124134448) do
     t.integer  "event_id"
     t.datetime "created_at",  :null => false
     t.datetime "updated_at",  :null => false
+    t.integer  "kind"
   end
 
   add_index "tickets", ["attendee_id", "event_id"], :name => "index_tickets_on_attendee_id_and_event_id", :unique => true

--- a/spec/models/attendee_spec.rb
+++ b/spec/models/attendee_spec.rb
@@ -62,26 +62,6 @@ describe Attendee do
     end
   end
 
-  describe "#kind" do
-    it "should be auto set" do
-      attendee = a_saved Attendee
-      attendee.kind.should be == Attendee::Kind::REGULAR
-    end
-
-    it "can not be nil" do
-      attendee = a_saved Attendee
-      attendee.kind = nil
-      attendee.save!
-      attendee.kind.should be == Attendee::Kind::REGULAR
-    end
-
-    it "can only be one of the valid types" do
-      attendee = a_saved Attendee
-      attendee.kind = 101
-      attendee.valid?.should be_false
-    end
-  end
-
   describe "#is_public" do
     it "can not be nil" do
       attendee = a Attendee

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -16,6 +16,26 @@ describe Ticket do
     end
   end
 
+  describe "#kind" do
+    it "should be auto set" do
+      ticket = a_saved Ticket
+      ticket.kind.should be == Ticket::Kind::REGULAR
+    end
+
+    it "can not be nil" do
+      ticket = a_saved Ticket
+      ticket.kind = nil
+      ticket.save!
+      ticket.kind.should be == Ticket::Kind::REGULAR
+    end
+
+    it "can only be one of the valid types" do
+      ticket = a_saved Ticket
+      ticket.kind = 101
+      ticket.valid?.should be_false
+    end
+  end
+
   describe "#interactions" do
     it "should have many interactions" do
       ticket = a_saved Ticket


### PR DESCRIPTION
Moving Kind to Ticket because attendees type changes per ticket. 

Event 1 they could be a sponsor
Event 2 they could be a attendee
Event 3 they could be crew. 

This change allows this level of flexibility. 
