### PR TITLE
Added some more interaction helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,6 @@ group :test do
   gem "object-factory",         github: "brightbox/object-factory"
   gem "rujitsu",                '0.3.3'
   gem "fivemat",                github: "caius/fivemat"
-  gem "cucumber-rails"
-  gem "capybara-webkit"
+  gem "cucumber-rails" ,        require: false
+  gem "capybara-webkit",        '0.14.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.0.0)
+    capybara-webkit (0.14.2)
       capybara (~> 2.0, >= 2.0.2)
       json
     colorize (0.5.8)
@@ -90,7 +90,7 @@ GEM
     jquery-rails (2.1.3)
       railties (>= 3.1.0, < 5.0)
       thor (~> 0.14)
-    json (1.7.7)
+    json (1.8.0)
     less (2.3.2)
       commonjs (~> 0.2.6)
     less-rails (2.3.3)
@@ -101,10 +101,12 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.21)
+    mime-types (1.23)
+    mini_portile (0.5.0)
     multi_json (1.7.1)
     multi_xml (0.5.3)
-    nokogiri (1.5.9)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
     pg (0.14.1)
     polyglot (0.3.3)
     rack (1.4.5)
@@ -177,7 +179,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print (= 1.1.0)
-  capybara-webkit
+  capybara-webkit (= 0.14.2)
   colorize
   createsend
   cucumber-rails

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -10,6 +10,8 @@ class Interaction < ActiveRecord::Base
 
   serialize :value, JSON
 
+  scope :search, ->(key, value, relation, ids){ where(key: key, value: value.to_json, current: true.to_json, interactable_type: relation.singularize.capitalize, interactable_id: ids) }
+
   protected
 
   def expire_previous_states

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,49 +5,50 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+require "rujitsu"
 
 #Venue
 venue = Venue.create!(:name => 'London Zoo', :address => 'Regents Park', :description => 'Come see the zoo')
 
 #Past event
 event1 = Event.create!(
-  :name => 'Mad Hatters Tea Party',
+  :name => "#{Faker::Name.first_name}'s' Tea Party",
   :url => 'http://bit.ly/teaparty',
   :venue => venue,
   :start_date => Time.now - 7.days,
-  :end_date => Time.now - 6.days
+  :end_date => Time.now - 6.days,
+  :eventbrite_xid => "123456"
 )
 
 #Upcoming event
 event2 = Event.create!(
-  :name => 'Mad Hatters Tea Party',
+  :name => "#{Faker::Name.first_name}'s' Tea Party",
   :url => 'http://bit.ly/teaparty',
   :venue => venue,
   :start_date => Time.now + 5.days,
-  :end_date => Time.now + 6.days
+  :end_date => Time.now + 6.days,
+  :eventbrite_xid => "654321"
 )
 
 (1..100).each do
 
   #Generate a attendee
-  attendee = Attendee.create({
+  attendee = Attendee.create!({
     first_name: Faker::Name.first_name,
     last_name: Faker::Name.last_name,
     twitter: Faker::Internet.user_name,
     is_public: true,
-    tshirt: rand(1..8)
+    tshirt: rand(1..8),
+    email: Faker::Internet.email
   }, :without_protection => true)
 
-  #Make sure the attendee has an email address
-  attendee.emails.create(address: Faker::Internet.email)
-
   #Setup a ticket for the previous week's event
-  ticket = Ticket.create(:attendee => attendee, :event => event1)
-  ticket.interactions.create(:key => 'confirmed', :value => [true, false].sample)
-  ticket.interactions.create(:key => 'cancelled', :value => [true, false].sample)
-  ticket.interactions.create(:key => 'arrived', :value => [true, false].sample)
+  ticket = Ticket.create!(:attendee => attendee, :event => event1, :eventbrite_xid => 10.random_numbers)
+  ticket.interactions.create!(:key => 'confirmed', :value => [true, false].sample)
+  ticket.interactions.create!(:key => 'cancelled', :value => [true, false].sample)
+  ticket.interactions.create!(:key => 'arrived', :value => [true, false].sample)
 
-  ticket = Ticket.create(:attendee => attendee, :event => event2)
-  ticket.interactions.create(:key => 'confirmed', :value => [true, false].sample)
-  ticket.interactions.create(:key => 'cancelled', :value => [true, false].sample)
+  ticket = Ticket.create!(:attendee => attendee, :event => event2, :eventbrite_xid => 10.random_numbers)
+  ticket.interactions.create!(:key => 'confirmed', :value => [true, false].sample)
+  ticket.interactions.create!(:key => 'cancelled', :value => [true, false].sample)
 end

--- a/spec/models/interactable_spec.rb
+++ b/spec/models/interactable_spec.rb
@@ -103,6 +103,62 @@ describe Interactable do
         expect(@interactable.has_foo?).to be_true
       end
     end
+
+    describe "#interaction_relation_count" do
+      before :all do
+        @event1 = a_saved Event
+        5.times do |i|
+          ticket = a_saved Ticket, attendee: a_saved(Attendee), event: @event1
+          ticket.has :confirmed, true
+          ticket.has :attending, i%3 == 0 ? true : false
+          ticket.has :attending_saturday, i%3 == 0 ? true : false
+        end
+
+        4.times do
+          ticket = a_saved Ticket, attendee: a_saved(Attendee), event: @event1
+          ticket.has :confirmed, false
+        end
+
+        @event2 = a_saved Event
+        10.times do
+          ticket = a_saved Ticket, attendee: a_saved(Attendee), event: @event2
+          ticket.has :confirmed, [true, false].sample
+          ticket.has :attending, [true, false].sample
+        end
+      end
+
+      it "should return a simple count of the interaction for the relations" do
+        expect(@event1.confirmed_tickets_count).to be == 5
+      end
+
+      it "should return a combined count of the interaction for the relations" do
+        expect(@event1.confirmed_and_attending_tickets_count).to be == 2
+      end
+
+      it "should return a 'not' count of the interaction for the relations" do
+        expect(@event1.not_confirmed_tickets_count).to be == 4
+      end
+
+      it "should return a 'not' combined count of the interaction for the relations" do
+        expect(@event1.confirmed_and_not_attending_tickets_count).to be == 3
+      end
+
+      it "should return a simple count of the 2 word interaction for a relation" do
+        expect(@event1.attending_saturday_tickets_count).to be == 2
+      end
+
+      it "should return a combined count of the 2 word interaction for a relation" do
+        expect(@event1.confirmed_and_attending_saturday_tickets_count).to be == 2
+      end
+
+      it "should return a combined count of the 2 word interaction for a relation including a not" do
+        expect(@event1.confirmed_and_not_attending_saturday_tickets_count).to be == 3
+      end
+
+      it "should return the counts of all interactions for a relation" do
+        expect(@event1.all_tickets_counts).to be == {"confirmed"=>5, "attending_saturday"=>2, "attending"=>2}
+      end
+    end
   end
 
   context "for classes" do


### PR DESCRIPTION
Re #95 

Adds count helpers. Had to fix capybara webkit to an older version but seems to work fine.

Allows you now to do things like:

``` ruby
@event.confirmed_tickets_count #=> counts number of current interactions on relation 'tickets' with type 'confirmed' 
@event.confirmed_and_attending_tickets_count #=> same as above but counts 2 types
@event.confirmed_and_not_attending_tickets_count #=> allows for mixing in "not"
@event.all_tickets_counts #=> returns a hash with all current counts
```

All of these count current records with the value set to true.
